### PR TITLE
Update README with package restore step

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In case you didn't install an IDE, you will need to manually install Git. Please
 
 Open a git bash terminal in the MissionPlanner directory and type, "git submodule update --init" to download all submodules
 
+Run a NuGet restore to download all package dependencies. From a command prompt you can use either `dotnet restore` or `.nuget\nuget.exe restore MissionPlanner.sln`.
+
 #### 3. Build
 
 To build the code:


### PR DESCRIPTION
## Summary
- document need for a NuGet restore before building

## Testing
- `dotnet restore MissionPlanner.sln` *(fails: project files missing)*
- `dotnet test MissionPlannerTests/MissionPlannerTests.csproj --no-build` *(fails: .NET Framework reference assemblies not found)*

------
https://chatgpt.com/codex/tasks/task_e_68870288f24c832a9982aadda7fb1989