### PR TITLE
Improve async networking and databinding

### DIFF
--- a/ExtLibs/Controls/QuickView.cs
+++ b/ExtLibs/Controls/QuickView.cs
@@ -11,12 +11,26 @@ using SkiaSharp.Views.Desktop;
 
 namespace MissionPlanner.Controls
 {
-    public partial class QuickView : SkiaSharp.Views.Desktop.SKControl
+    public partial class QuickView : SkiaSharp.Views.Desktop.SKControl, INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
         [System.ComponentModel.Browsable(true)]
         public string desc
         {
-            get { return _desc; } set { if (_desc == value) return; _desc = value; Invalidate(); }
+            get { return _desc; }
+            set
+            {
+                if (_desc == value)
+                    return;
+                _desc = value;
+                OnPropertyChanged(nameof(desc));
+                Invalidate();
+            }
         }
 
         double _number = -9999;
@@ -32,6 +46,7 @@ namespace MissionPlanner.Controls
                     if (_number.Equals(value))
                         return;
                     _number = value;
+                    OnPropertyChanged(nameof(number));
                     Invalidate();
                 }
             }
@@ -53,12 +68,24 @@ namespace MissionPlanner.Controls
                 if (_numberformat.Equals(value))
                     return;
                 _numberformat = value;
+                OnPropertyChanged(nameof(numberformat));
                 this.Invalidate();
             }
         }
 
         [System.ComponentModel.Browsable(true)]
-        public Color numberColor { get { return _numbercolor; } set { if (_numbercolor == value) return; _numbercolor = value; Invalidate(); } }
+        public Color numberColor
+        {
+            get { return _numbercolor; }
+            set
+            {
+                if (_numbercolor == value)
+                    return;
+                _numbercolor = value;
+                OnPropertyChanged(nameof(numberColor));
+                Invalidate();
+            }
+        }
 
         //We use this property as a backup store for the numberColor, so it is possible to change numberColor temporary.
         public Color numberColorBackup { get; set; }

--- a/ExtLibs/Mavlink/MavlinkParse.cs
+++ b/ExtLibs/Mavlink/MavlinkParse.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 public partial class MAVLink
 {
@@ -125,6 +126,52 @@ public partial class MAVLink
             }
         }
 
+        public static async Task ReadWithTimeoutAsync(Stream BaseStream, byte[] buffer, int offset, int count)
+        {
+            int timeout = 500;
+
+            if (BaseStream.CanSeek)
+            {
+                timeout = 0;
+
+                if ((BaseStream.Position + count) > BaseStream.Length)
+                    throw new EndOfStreamException("End of data");
+            }
+
+            if (BaseStream.CanTimeout)
+            {
+                timeout = BaseStream.ReadTimeout;
+
+                if (timeout == -1)
+                    timeout = 60000;
+            }
+
+            DateTime to = DateTime.UtcNow.AddMilliseconds(timeout);
+
+            int toread = count;
+            int pos = offset;
+
+            while (true)
+            {
+                int read = await BaseStream.ReadAsync(buffer, pos, toread);
+
+                toread -= read;
+                pos += read;
+
+                if (read > 0)
+                    to = DateTime.UtcNow.AddMilliseconds(timeout);
+
+                if (toread == 0)
+                    break;
+
+                if (DateTime.UtcNow > to)
+                {
+                    throw new TimeoutException("Timeout waiting for data");
+                }
+                await Task.Delay(1);
+            }
+        }
+
         public MAVLinkMessage ReadPacket(Stream BaseStream)
         {
             byte[] buffer = new byte[MAVLink.MAVLINK_MAX_PACKET_LEN];
@@ -227,6 +274,105 @@ public partial class MAVLink
             {
                 badCRC++;
                 // crc fail
+                return null;
+            }
+
+            return message;
+        }
+
+        public async Task<MAVLinkMessage> ReadPacketAsync(Stream BaseStream)
+        {
+            byte[] buffer = new byte[MAVLink.MAVLINK_MAX_PACKET_LEN];
+
+            DateTime packettime = DateTime.MinValue;
+
+            if (hasTimestamp)
+            {
+                byte[] datearray = new byte[8];
+
+                int tem = await BaseStream.ReadAsync(datearray, 0, datearray.Length);
+
+                Array.Reverse(datearray);
+
+                DateTime date1 = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                UInt64 dateint = BitConverter.ToUInt64(datearray, 0);
+
+                if ((dateint / 1000 / 1000 / 60 / 60) < 9999999)
+                {
+                    date1 = date1.AddMilliseconds(dateint / 1000);
+
+                    packettime = date1.ToLocalTime();
+                }
+            }
+
+            int readcount = 0;
+
+            while (readcount <= MAVLink.MAVLINK_MAX_PACKET_LEN)
+            {
+                await ReadWithTimeoutAsync(BaseStream, buffer, 0, 1);
+
+                if (buffer[0] == MAVLink.MAVLINK_STX || buffer[0] == MAVLINK_STX_MAVLINK1)
+                    break;
+
+                readcount++;
+            }
+
+            if (readcount >= MAVLink.MAVLINK_MAX_PACKET_LEN)
+            {
+                return null;
+            }
+
+            var headerlength = buffer[0] == MAVLINK_STX ? MAVLINK_CORE_HEADER_LEN : MAVLINK_CORE_HEADER_MAVLINK1_LEN;
+            var headerlengthstx = headerlength + 1;
+
+            try
+            {
+                await ReadWithTimeoutAsync(BaseStream, buffer, 1, headerlength);
+            }
+            catch (EndOfStreamException)
+            {
+                return null;
+            }
+
+            int lengthtoread = 0;
+            if (buffer[0] == MAVLINK_STX)
+            {
+                lengthtoread = buffer[1] + headerlengthstx + 2 - 2;
+                if ((buffer[2] & MAVLINK_IFLAG_SIGNED) > 0)
+                {
+                    lengthtoread += MAVLINK_SIGNATURE_BLOCK_LEN;
+                }
+            }
+            else
+            {
+                lengthtoread = buffer[1] + headerlengthstx + 2 - 2;
+            }
+
+            try
+            {
+                await ReadWithTimeoutAsync(BaseStream, buffer, headerlengthstx, lengthtoread - (headerlengthstx - 2));
+            }
+            catch (EndOfStreamException)
+            {
+                return null;
+            }
+
+            Array.Resize<byte>(ref buffer, lengthtoread + 2);
+
+            MAVLinkMessage message = new MAVLinkMessage(buffer, packettime);
+
+            ushort crc = MavlinkCRC.crc_calculate(buffer, buffer.Length - 2);
+
+            if (message.header == MAVLINK_STX || message.header == MAVLINK_STX_MAVLINK1)
+            {
+                crc = MavlinkCRC.crc_accumulate(MAVLINK_MESSAGE_INFOS.GetMessageInfo(message.msgid).crc, crc);
+            }
+
+            if ((message.crc16 >> 8) != (crc >> 8) ||
+                      (message.crc16 & 0xff) != (crc & 0xff))
+            {
+                badCRC++;
                 return null;
             }
 

--- a/Utilities/httpserver.cs
+++ b/Utilities/httpserver.cs
@@ -11,6 +11,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace MissionPlanner.Utilities
@@ -92,6 +93,39 @@ namespace MissionPlanner.Utilities
                 catch (ThreadAbortException ex)
                 {
                     log.Info(ex);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    log.Error(ex);
+                }
+            }
+        }
+
+        public async Task listernforclientsAsync(CancellationToken token)
+        {
+            try
+            {
+                listener = new TcpListener(IPAddress.Any, 56781);
+
+                listener.Start();
+            }
+            catch (Exception e)
+            {
+                log.Error("Exception starting listener. Possible multiple instances of planner?", e);
+                return;
+            }
+
+            while (run && !token.IsCancellationRequested)
+            {
+                try
+                {
+                    log.Info("Listening for client");
+                    var client = await listener.AcceptTcpClientAsync();
+                    _ = Task.Run(() => ProcessClient(client), token);
+                }
+                catch (ObjectDisposedException)
+                {
                     return;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Summary
- implement `INotifyPropertyChanged` for `QuickView` control for better data binding
- add async helpers `ReadWithTimeoutAsync` and `ReadPacketAsync` to `MavlinkParse`
- add async network listener `listernforclientsAsync` in `httpserver`

## Testing
- `dotnet test MissionPlannerTests/MissionPlannerTests.csproj -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68852efc3be8832a91315a0f21b5aa4a