### PR TITLE
Add color threshold progress indicators

### DIFF
--- a/Controls/EKFStatus.cs
+++ b/Controls/EKFStatus.cs
@@ -32,11 +32,8 @@ namespace MissionPlanner.Controls
 
             foreach (var item in new VerticalProgressBar2[] { ekfvel, ekfposh, ekfposv, ekfcompass, ekfterrain })
             {
-                if (item.Value > 50)
-                    item.ValueColor = Color.Orange;
-
-                if (item.Value > 80)
-                    item.ValueColor = Color.Red;
+                item.WarningThreshold = 50;
+                item.CriticalThreshold = 80;
             }
 
             int idx = 0;

--- a/ExtLibs/Controls/HorizontalProgressBar.cs
+++ b/ExtLibs/Controls/HorizontalProgressBar.cs
@@ -36,6 +36,13 @@ namespace MissionPlanner.Controls
         bool ctladded = false;
         bool _drawlabel = true;
 
+        private Color _normalColor;
+        private Color _warningColor = Color.Orange;
+        private Color _criticalColor = Color.Red;
+
+        public int WarningThreshold { get; set; } = int.MaxValue;
+        public int CriticalThreshold { get; set; } = int.MaxValue;
+
         [System.ComponentModel.Browsable(true),
 System.ComponentModel.Category("Mine"),
 System.ComponentModel.Description("draw text under Bar")]
@@ -69,6 +76,7 @@ System.ComponentModel.Description("draw text under Bar")]
             drawlbl();
             Maximum = 100;
             Minimum = 0;
+            _normalColor = this.ForeColor;
         }
 
         public new int Value
@@ -80,6 +88,7 @@ System.ComponentModel.Description("draw text under Bar")]
                     return;
 
                 _value = value;
+                UpdateValueColor();
                 int ans = value + offset;
                 if (ans <= base.Minimum)
                 {
@@ -216,8 +225,25 @@ System.ComponentModel.Description("Text under Bar")]
         public int minline { get; set; }
         public int maxline { get; set; }
 
+        private void UpdateValueColor()
+        {
+            if (_value >= CriticalThreshold)
+            {
+                this.ForeColor = _criticalColor;
+            }
+            else if (_value >= WarningThreshold)
+            {
+                this.ForeColor = _warningColor;
+            }
+            else
+            {
+                this.ForeColor = _normalColor;
+            }
+        }
+
         protected new void OnPaint(PaintEventArgs e)
         {
+            UpdateValueColor();
             base.OnPaint(e);
             drawlbl();
         }

--- a/ExtLibs/Controls/HorizontalProgressBar2.cs
+++ b/ExtLibs/Controls/HorizontalProgressBar2.cs
@@ -39,6 +39,14 @@ namespace MissionPlanner.Controls
         int displayvalue = 0;
         bool _drawlabel = true;
 
+        private Color _normalValueColor;
+        private Color _warningValueColor = Color.Orange;
+        private Color _criticalValueColor = Color.Red;
+
+        public int WarningThreshold { get; set; } = int.MaxValue;
+        public int CriticalThreshold { get; set; } = int.MaxValue;
+
+
         //BSE.Windows.Forms.ProgressBar basepb = new BSE.Windows.Forms.ProgressBar();
 
         [System.ComponentModel.Browsable(true),
@@ -80,6 +88,8 @@ System.ComponentModel.Description("draw text under Bar")]
     ControlStyles.AllPaintingInWmPaint |
     ControlStyles.SupportsTransparentBackColor |
     ControlStyles.UserPaint, true);
+
+            _normalValueColor = this.ValueColor;
         }
 
         public new int Value
@@ -97,6 +107,8 @@ System.ComponentModel.Description("draw text under Bar")]
                     int dif = _value - Minimum;
                     _value = Maximum - dif;
                 }
+
+                UpdateValueColor();
 
                 int ans = _value + offset;
                 if (ans <= base.Minimum)
@@ -163,6 +175,22 @@ System.ComponentModel.Description("values scaled for display")]
         }
 
         private float _displayscale = 1;
+
+        private void UpdateValueColor()
+        {
+            if (displayvalue >= CriticalThreshold)
+            {
+                this.ValueColor = _criticalValueColor;
+            }
+            else if (displayvalue >= WarningThreshold)
+            {
+                this.ValueColor = _warningValueColor;
+            }
+            else
+            {
+                this.ValueColor = _normalValueColor;
+            }
+        }
 
         StringFormat drawFormat = new StringFormat() { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Center };
 
@@ -245,6 +273,7 @@ System.ComponentModel.Description("values scaled for display")]
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            UpdateValueColor();
             base.OnPaint(e);
             drawlbl(e.Graphics);
         }


### PR DESCRIPTION
## Summary
- support warning and critical threshold colors in progress bars
- apply threshold settings in EKF status display

## Testing
- ❌ `msbuild -version` *(fails: command not found)*
- ❌ `xbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852273e994832ab78c4485c0191395