### PR TITLE
Add animated vehicle markers and toggle

### DIFF
--- a/ExtLibs/Maps/GMapMarkerBase.cs
+++ b/ExtLibs/Maps/GMapMarkerBase.cs
@@ -14,6 +14,7 @@ namespace MissionPlanner.Maps
         public static bool DisplayNavBearingSetting = true;
         public static bool DisplayRadiusSetting = true;
         public static bool DisplayTargetSetting = true;
+        public static bool AnimateIcons = false;
         public static int length = 500;
         public static InactiveDisplayStyleEnum InactiveDisplayStyle = InactiveDisplayStyleEnum.Normal;
         

--- a/ExtLibs/Maps/GMapMarkerPlane.cs
+++ b/ExtLibs/Maps/GMapMarkerPlane.cs
@@ -186,6 +186,12 @@ namespace MissionPlanner.Maps
             if (which % 7 == 6)
                 color = Color.Pink;
 
+            if (AnimateIcons)
+            {
+                int mod = (int)(Math.Abs(Math.Sin(Environment.TickCount / 200.0)) * 60);
+                color = Color.FromArgb(Math.Min(color.R + mod, 255), Math.Min(color.G + mod, 255), Math.Min(color.B + mod, 255));
+            }
+
             if(IsTransparent)
             {
                 color = Color.FromArgb(100, color);

--- a/ExtLibs/Maps/GMapMarkerQuad.cs
+++ b/ExtLibs/Maps/GMapMarkerQuad.cs
@@ -128,6 +128,15 @@ namespace MissionPlanner.Maps
                 return;
             }
 
+            if (AnimateIcons)
+            {
+                framerotation = (framerotation + 10) % 360;
+            }
+            else
+            {
+                framerotation = 0;
+            }
+
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
             g.TranslateTransform(-Offset.X, -Offset.Y);

--- a/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerBase.cs
+++ b/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerBase.cs
@@ -14,6 +14,7 @@ namespace MissionPlanner.Maps
         public static bool DisplayNavBearing = true;
         public static bool DisplayRadius = true;
         public static bool DisplayTarget = true;
+        public static bool AnimateIcons = false;
         public static int length = 500;
 
         public GMapMarkerBase(PointLatLng pos):base(pos)

--- a/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerPlane.cs
+++ b/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerPlane.cs
@@ -122,19 +122,25 @@ namespace MissionPlanner.Maps
             }
 
             // 'which' variable simply selects different coloured plane icon/s from the resource library
-            if (which == 0)
+            var draw = which;
+            if (AnimateIcons)
+            {
+                draw = (int)((Environment.TickCount / 200) % 7);
+            }
+
+            if (draw == 0)
                 g.DrawImageUnscaled(icon, icon.Width / -2, icon.Height / -2);
-            if (which == 1)
+            if (draw == 1)
                 g.DrawImageUnscaled(icon1, icon1.Width / -2, icon1.Height / -2);
-            if (which == 2)
+            if (draw == 2)
                 g.DrawImageUnscaled(icon2, icon2.Width / -2, icon2.Height / -2);
-            if (which == 3)
+            if (draw == 3)
                 g.DrawImageUnscaled(icon3, icon3.Width / -2, icon3.Height / -2);
-            if (which == 4)
+            if (draw == 4)
                 g.DrawImageUnscaled(icon4, icon4.Width / -2, icon4.Height / -2);
-            if (which == 5)
+            if (draw == 5)
                 g.DrawImageUnscaled(icon5, icon5.Width / -2, icon5.Height / -2);
-            if (which == 6)
+            if (draw == 6)
                 g.DrawImageUnscaled(icon6, icon6.Width / -2, icon6.Height / -2);
 
 

--- a/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerQuad.cs
+++ b/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerQuad.cs
@@ -18,6 +18,7 @@ namespace MissionPlanner.Maps
 
         public float warn = -1;
         public float danger = -1;
+        private float framerotation = 0;
 
         public GMapMarkerQuad(PointLatLng p, float heading, float cog, float target, int sysid)
             : base(p)
@@ -31,6 +32,14 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if (AnimateIcons)
+            {
+                framerotation = (framerotation + 10) % 360;
+            }
+            else
+            {
+                framerotation = 0;
+            }
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -64,7 +73,11 @@ namespace MissionPlanner.Maps
             {
             }
 
+            g.RotateTransform(framerotation);
+
             g.DrawImageUnscaled(icon, icon.Width / -2 + 2, icon.Height / -2);
+
+            g.RotateTransform(-framerotation);
 
             g.DrawString(sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), Brushes.Red, -8,
                 -8);

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -29,6 +29,7 @@ namespace MissionPlanner.GCSViews
             this.groundColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setBatteryCellCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showIconsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.animatedIconsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bindingSourceHud = new System.Windows.Forms.BindingSource(this.components);
             this.contextMenuStripactionstab = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.customizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -462,7 +463,8 @@ namespace MissionPlanner.GCSViews
             this.swapWithMapToolStripMenuItem,
             this.groundColorToolStripMenuItem,
             this.setBatteryCellCountToolStripMenuItem,
-            this.showIconsToolStripMenuItem});
+            this.showIconsToolStripMenuItem,
+            this.animatedIconsToolStripMenuItem});
             this.contextMenuStripHud.Name = "contextMenuStrip2";
             resources.ApplyResources(this.contextMenuStripHud, "contextMenuStripHud");
             // 
@@ -563,7 +565,13 @@ namespace MissionPlanner.GCSViews
             this.showIconsToolStripMenuItem.Name = "showIconsToolStripMenuItem";
             resources.ApplyResources(this.showIconsToolStripMenuItem, "showIconsToolStripMenuItem");
             this.showIconsToolStripMenuItem.Click += new System.EventHandler(this.showIconsToolStripMenuItem_Click);
-            // 
+            //
+            // animatedIconsToolStripMenuItem
+            //
+            this.animatedIconsToolStripMenuItem.Name = "animatedIconsToolStripMenuItem";
+            resources.ApplyResources(this.animatedIconsToolStripMenuItem, "animatedIconsToolStripMenuItem");
+            this.animatedIconsToolStripMenuItem.Click += new System.EventHandler(this.animatedIconsToolStripMenuItem_Click);
+            //
             // bindingSourceHud
             // 
             this.bindingSourceHud.DataSource = typeof(MissionPlanner.CurrentState);
@@ -3183,6 +3191,7 @@ namespace MissionPlanner.GCSViews
         private System.Windows.Forms.TextBox NACp_tb;
         private System.Windows.Forms.TextBox NIC_tb;
         private ToolStripMenuItem showIconsToolStripMenuItem;
+        private ToolStripMenuItem animatedIconsToolStripMenuItem;
         private ToolStripMenuItem multiLineToolStripMenuItem;
         private Controls.MyButton BUT_SendMSG;
         public Panel panel_persistent;

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -6437,6 +6437,12 @@ namespace MissionPlanner.GCSViews
             }
         }
 
+        private void animatedIconsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            MissionPlanner.Maps.GMapMarkerBase.AnimateIcons = !MissionPlanner.Maps.GMapMarkerBase.AnimateIcons;
+            animatedIconsToolStripMenuItem.Checked = MissionPlanner.Maps.GMapMarkerBase.AnimateIcons;
+        }
+
         private void multiLineToolStripMenuItem_Click(object sender, EventArgs e)
         {
             tabControlactions.Multiline = !tabControlactions.Multiline;

--- a/GCSViews/FlightData.resx
+++ b/GCSViews/FlightData.resx
@@ -233,8 +233,14 @@
   <data name="showIconsToolStripMenuItem.Text" xml:space="preserve">
     <value>Show icons</value>
   </data>
+  <data name="animatedIconsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>176, 22</value>
+  </data>
+  <data name="animatedIconsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Animated Icons</value>
+  </data>
   <data name="contextMenuStripHud.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 180</value>
+    <value>177, 202</value>
   </data>
   <data name="&gt;&gt;contextMenuStripHud.Name" xml:space="preserve">
     <value>contextMenuStripHud</value>
@@ -6221,6 +6227,12 @@
     <value>showIconsToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;showIconsToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;animatedIconsToolStripMenuItem.Name" xml:space="preserve">
+    <value>animatedIconsToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;animatedIconsToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;bindingSourceHud.Name" xml:space="preserve">


### PR DESCRIPTION
## Summary
- enable animated icons in the marker base
- pulse plane marker colour when animation is enabled
- rotate quadcopter marker graphics for animation
- add toggle menu item to activate animated icons

## Testing
- `git log -1 --stat`
- `git status --short`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68852416de68832a9acac877e07a8ef0